### PR TITLE
Handle multiple psuedo classes/elements & improveme readability

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,10 @@
+'use strict';
+
+/**
+ * @file    ESLint setup
+ * @author  TheJaredWilcurt
+ */
+
 module.exports = {
   parser: 'babel-eslint',
   parserOptions: {
@@ -14,6 +21,14 @@ module.exports = {
     'tjw-jsdoc'
   ],
   rules: {
+    'max-lines-per-function': [
+      'warn',
+      {
+        max: 50,
+        skipBlankLines: true,
+        skipComments: true
+      }
+    ],
     'jsdoc/require-example': 'off'
   }
 };

--- a/manual-testing.js
+++ b/manual-testing.js
@@ -29,7 +29,10 @@ redPerfume.atomize({
           }
         `,
         result: function (result, err) {
-          console.log(result, err);
+          console.log(result);
+          if (err) {
+            console.log(err);
+          }
         }
       },
       markup: [
@@ -58,14 +61,20 @@ redPerfume.atomize({
           `,
           out: './manual-test/out.html',
           result: function (result, err) {
-            console.log(result, err);
+            console.log(result);
+            if (err) {
+              console.log(err);
+            }
           }
         }
       ],
       scripts: {
         out: './manual-test/out.json',
         result: function (result, err) {
-          console.log(result, err);
+          console.log(result);
+          if (err) {
+            console.log(err);
+          }
         }
       }
     }

--- a/src/css.js
+++ b/src/css.js
@@ -35,7 +35,7 @@ function recursivelyRemovePosition (item) {
 }
 
 /**
- * Remove duplicate property/value pairs that are duplicates.
+ * Remove property/value pairs that are duplicates.
  * `display: none; display: none;` becomes `display:none;`
  * `display: block; display: none;` is unchanged because they
  * are not identical.
@@ -46,6 +46,9 @@ function recursivelyRemovePosition (item) {
 function removeIdenticalProperties (classMap) {
   // Remove identical properties
   Object.keys(classMap).forEach(function (selector) {
+    // The double reverse is so the last duplicate is kept in place, and the previous are removed
+    // ['.rp__margin__--COLON2px', '.rp__margin__--COLON2px', '.rp__border__--COLON0px', '.rp__margin__--COLON2px'] =>
+    // ['.rp__border__--COLON0px', '.rp__margin__--COLON2px']
     classMap[selector] = Array.from(new Set(classMap[selector].reverse())).reverse();
   });
   return classMap;
@@ -60,19 +63,48 @@ function removeIdenticalProperties (classMap) {
  * @return {object}                   Returns the classMap object
  */
 function updateClassMap (classMap, selectors, encodedClassName) {
-  /* A selector looks like:
-    [{
-      type: 'attribute',
-      name: 'class',
-      action: 'element',
-      value: 'cow',
-      ignoreCase: false,
-      namespace: null,
-      original: '.cow'
-      }]
-    */
+  /*
+    An array of selectors for
+    .cat:hover, .bat:hover { margin: 2px; }
+    looks like:
+    [
+      [
+        {
+          "type": "attribute",
+          "name": "class",
+          "action": "element",
+          "value": "cat",
+          "namespace": null,
+          "ignoreCase": false,
+          "original": ".cat:hover"
+        },
+        {
+          "type": "pseudo",
+          "name": "hover",
+          "data": null
+        }
+      ],
+      [
+        {
+          "type": "attribute",
+          "name": "class",
+          "action": "element",
+          "value": "bat",
+          "namespace": null,
+          "ignoreCase": false,
+          "original": ".bat:hover"
+        },
+        {
+          "type": "pseudo",
+          "name": "hover",
+          "data": null
+        }
+      ]
+    ]
+  */
   selectors.forEach(function (selector) {
     let originalSelectorName = selector[0].original;
+    // '.cow:hover' => '.cow'
     originalSelectorName = originalSelectorName.split(':')[0];
 
     classMap[originalSelectorName] = classMap[originalSelectorName] || [];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,24 +7,6 @@
 
 const helpers = {
   /**
-   * Finds and removes every instance of a value from an array.
-   *
-   * @param  {Array} arr    Any array
-   * @param  {any}   value  Any literal that can be compared with ===
-   * @return {Array}        The mutated array
-   */
-  removeEveryInstance: function (arr, value) {
-    let i = 0;
-    while (i < arr.length) {
-      if (arr[i] === value) {
-        arr.splice(i, 1);
-      } else {
-        ++i;
-      }
-    }
-    return arr;
-  },
-  /**
    * Either calls the customLogger or does
    * console.error when errors/warnings happen
    * during validation or execution.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,6 +7,24 @@
 
 const helpers = {
   /**
+   * Finds and removes every instance of a value from an array.
+   *
+   * @param  {Array} arr    Any array
+   * @param  {any}   value  Any literal that can be compared with ===
+   * @return {Array}        The mutated array
+   */
+  removeEveryInstance: function (arr, value) {
+    let i = 0;
+    while (i < arr.length) {
+      if (arr[i] === value) {
+        arr.splice(i, 1);
+      } else {
+        ++i;
+      }
+    }
+    return arr;
+  },
+  /**
    * Either calls the customLogger or does
    * console.error when errors/warnings happen
    * during validation or execution.

--- a/src/html.js
+++ b/src/html.js
@@ -42,43 +42,48 @@ function cleanDocument (document) {
 cleanDocument({});
 
 /**
- * Finds and removes every instance of a value from an array.
- *
- * @param  {Array} arr    Any array
- * @param  {any}   value  Any literal that can be compared with ===
- * @return {Array}        The mutated array
- */
-function removeEveryInstance (arr, value) {
-  let i = 0;
-  while (i < arr.length) {
-    if (arr[i] === value) {
-      arr.splice(i, 1);
-    } else {
-      ++i;
-    }
-  }
-  return arr;
-}
-
-/**
  * Replaces all instances of a class name in class attributes in the DOM
  * with its atomized representation of class names.
  *
- * @param  {object}    node            An HTML AST node
+ * @param  {object}    node            An HTML node as AST
  * @param  {string}    classToReplace  A string to find and replace
  * @param  {Array}     newClasses      Array of strings that will replace the given class
  * @return {undefined}                 Just mutates the AST. Nothing returned
  */
 function replaceSemanticClassWithAtomizedClasses (node, classToReplace, newClasses) {
+  /* An example of a Node:
+    {
+      nodeName: 'h1',
+      tagName: 'h1',
+      attrs: [
+        {
+          name: 'class',
+          value: 'cool cat nice wow'
+        }
+      ],
+      namespaceURI: 'http://www.w3.org/1999/xhtml',
+      childNodes: [
+        {
+          nodeName: '#text',
+          value: '\n                  Meow\n                '
+        }
+      ]
+    }
+  */
   if (node.attrs) {
     node.attrs.forEach(function (attribute) {
       if (attribute.name === 'class') {
+        // console.log(JSON.stringify(cleanDocument(node), null, 2));
+        // 'cool cat nice wow' => ['cool','cat','nice','wow']
         let classes = attribute.value.split(' ');
         if (classes.includes(classToReplace)) {
-          classes = removeEveryInstance(classes, classToReplace);
-          classes.push(...newClasses);
+          classes = helpers.removeEveryInstance(classes, classToReplace);
+          classes = [
+            ...classes,
+            ...newClasses
+          ];
+          attribute.value = classes.join(' ');
         }
-        attribute.value = classes.join(' ');
       }
     });
   }

--- a/src/html.js
+++ b/src/html.js
@@ -77,11 +77,16 @@ function replaceSemanticClassWithAtomizedClasses (node, classToReplace, newClass
         // 'cool cat nice wow' => ['cool','cat','nice','wow']
         let classes = attribute.value.split(' ');
         if (classes.includes(classToReplace)) {
-          classes = helpers.removeEveryInstance(classes, classToReplace);
+          // ['cool','cat','nice','wow'] => ['cool','nice','wow']
+          classes = classes.filter(function (className) {
+            return className !== classToReplace;
+          });
+          // ['cool','cat','nice','wow','rp__4','rp__8']
           classes = [
             ...classes,
             ...newClasses
           ];
+          // 'cool cat nice wow rp__4 rp__8'
           attribute.value = classes.join(' ');
         }
       }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/css-class-encoding.test.js
+++ b/tests/src/css-class-encoding.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/css-parser.test.js
+++ b/tests/src/css-parser.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/css-stringify.test.js
+++ b/tests/src/css-stringify.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/css-uglifier.test.js
+++ b/tests/src/css-uglifier.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/css.test.js
+++ b/tests/src/css.test.js
@@ -222,6 +222,9 @@ describe('CSS', () => {
         .example:visited {
           color: #00F;
         }
+        .example:hover:after {
+          content: '';
+        }
         h1:hover {
           color: #F00;
         }
@@ -253,6 +256,9 @@ describe('CSS', () => {
           }
           .rp__color__--COLON__--OCTOTHORP00F___-VISITED:visited {
             color: #00F;
+          }
+          .rp__content__--COLON__--SINGLEQUOTE__--SINGLEQUOTE___-HOVER___-AFTER:hover:after {
+            content: '';
           }
           h1:hover {
             color: #F00;
@@ -291,13 +297,16 @@ describe('CSS', () => {
           .rp__5:visited {
             color: #00F;
           }
-          .rp__6 {
-            background: #F00;
+          .rp__6:hover:after {
+            content: '';
           }
           .rp__7 {
+            background: #F00;
+          }
+          .rp__8 {
             color: #00F;
           }
-          .rp__8:hover {
+          .rp__9:hover {
             background: #0F0;
           }
         `, 10));

--- a/tests/src/css.test.js
+++ b/tests/src/css.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/html.test.js
+++ b/tests/src/html.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file

--- a/tests/src/validator.test.js
+++ b/tests/src/validator.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable max-lines-per-function */
 
 /**
  * @file    Testing file


### PR DESCRIPTION
<!-- Change the ## to your pull request number -->
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TheJaredWilcurt/9c5d16fe3fa8f8ef414fe8b0eff17f7f/raw/red-perfume__pull_64.json)

<!-- Replace 0 with the issue number -->
**Related Issue:** #0


**Notes for reviewer:**

* Improve comments
* Add linting rule to force breaking up big functions into smaller functions
* split out functions into smaller functions
* handle multiple psuedo classes (`.cow:after:hover`)
